### PR TITLE
[WIP] Tweaks for the queueable tech exe

### DIFF
--- a/libwololokingdoms/fixes/queuetechs.cpp
+++ b/libwololokingdoms/fixes/queuetechs.cpp
@@ -439,6 +439,9 @@ int processTech(genie::DatFile * df, int techId, bool reserveIds, int numSkipped
 
   // Appends the unit to every civilization.
   for (auto& civ : df->Civs) {
+    unit.ID = civ.Units.size();
+    unit.CopyID = civ.Units.size();
+    unit.BaseID = civ.Units.size();
     civ.Units.push_back(unit);
     civ.UnitPointers.push_back(1); // All Unit Pointers are 1.
   }

--- a/libwololokingdoms/fixes/queuetechs.cpp
+++ b/libwololokingdoms/fixes/queuetechs.cpp
@@ -2,6 +2,7 @@
 #include "wololo/datPatch.h"
 #include <cassert>
 #include <unordered_map>
+#include <cassert>
 
 using std::unordered_map;
 
@@ -143,6 +144,11 @@ const int16_t RESOURCE_ATTRIBUTES[] = {
     genie::EffectCommand::Attributes::StoneCosts
 };
 
+// Flag to indicate that this unit should not be shown in the editor.
+const int8_t HIDE_IN_EDITOR_FLAG = 1;
+// Flag to indicate that this unit is a queueable tech dummy.
+const int8_t QUEUEABLE_TECH_FLAG = 2;
+
 // Returns `true` if `techId` represents an age, `false` otherwise.
 // Ages are given by ids:
 //   * Dark Age     - 101
@@ -155,7 +161,7 @@ const int16_t RESOURCE_ATTRIBUTES[] = {
 // @param techId the technology id to check
 bool isAge(int techId) { return 101 <= techId && techId <= 104; }
 
-	/// Returns `true` if `techId` represents a mill technology (farm upgrade),
+/// Returns `true` if `techId` represents a mill technology (farm upgrade),
 /// `false` otherwise.
 bool isMillTech(int techId) {
   return techId == TECH_ID_HORSE_COLLAR || techId == TECH_ID_HEAVY_PLOW ||
@@ -252,6 +258,8 @@ void initializeUnit(genie::Unit& unit, int resId, genie::Tech& tech) {
   unit.LanguageDLLHelp = tech.LanguageDLLHelp;
   unit.LanguageDLLCreation = tech.LanguageDLLDescription;
   unit.TerrainRestriction = 0;
+  unit.Name = tech.Name + " (Queueable Dummy)";
+  unit.HideInEditor = HIDE_IN_EDITOR_FLAG | QUEUEABLE_TECH_FLAG;
 
   unit.Creatable.TrainTime = tech.ResearchTime;
   unit.Creatable.TrainLocationID = tech.ResearchLocation;

--- a/libwololokingdoms/fixes/queuetechs.cpp
+++ b/libwololokingdoms/fixes/queuetechs.cpp
@@ -2,7 +2,6 @@
 #include "wololo/datPatch.h"
 #include <cassert>
 #include <unordered_map>
-#include <cassert>
 
 using std::unordered_map;
 

--- a/libwololokingdoms/slp.h
+++ b/libwololokingdoms/slp.h
@@ -247,7 +247,7 @@ struct slp {
   /// The outline table, command table, and drawing commands of each
   /// frame of the slp file, size must equal the number of frames
   /// specified by the header.
-  std::vector<frame_data> frame_data;
+  std::vector<::frame_data> frame_data;
 };
 
 /// Reads an slp file from `in` and returns a struct representing it.

--- a/libwololokingdoms/wkconverter.cpp
+++ b/libwololokingdoms/wkconverter.cpp
@@ -2152,21 +2152,30 @@ void WKConverter::symlinkSetup(const fs::path& oldDir, const fs::path& newDir,
 int WKConverter::retryInstall() {
   listener->log("Retry installation with removing folders first");
   fs::path tempFolder = "retryTemp";
+
+  /// Copy a file or directory from path `from` to path `to`, if `from` exists.
+  auto copy_if = [](const auto& from, const auto& to, auto options) {
+    if (cfs::exists(from)) {
+      cfs::copy(from, to, options);
+    }
+  };
+
+  /// Copy a file from path `from` to path `to`, if `from` exists.
+  auto copy_file_if = [](const auto& from, const auto& to, auto options) {
+    if (cfs::exists(from)) {
+      cfs::copy_file(from, to, options);
+    }
+  };
+
   try {
     cfs::create_directories(tempFolder / "Scenario");
     cfs::create_directories(tempFolder / "SaveGame");
     cfs::create_directories(tempFolder / "Script.RM");
-    cfs::copy(installDir / "SaveGame", tempFolder / "SaveGame",
-              fs::copy_options::recursive | fs::copy_options::update_existing);
-    cfs::copy(installDir / "Script.RM", tempFolder / "Script.RM",
-              fs::copy_options::recursive | fs::copy_options::update_existing);
-    cfs::copy(installDir / "Scenario", tempFolder / "Scenario",
-              fs::copy_options::recursive | fs::copy_options::update_existing);
-    cfs::copy_file(installDir / "player.nfz", tempFolder / "player.nfz",
-                   fs::copy_options::update_existing);
-    if (cfs::exists(installDir / "player1.hki"))
-      cfs::copy_file(installDir / "player1.hki", tempFolder / "player1.hki",
-                     fs::copy_options::update_existing);
+    copy_if(installDir / "SaveGame", tempFolder / "SaveGame", fs::copy_options::recursive | fs::copy_options::update_existing);
+    copy_if(installDir / "Script.RM", tempFolder / "Script.RM", fs::copy_options::recursive | fs::copy_options::update_existing);
+    copy_if(installDir / "Scenario", tempFolder / "Scenario", fs::copy_options::recursive | fs::copy_options::update_existing);
+    copy_file_if(installDir / "player.nfz", tempFolder / "player.nfz", fs::copy_options::update_existing);
+    copy_file_if(installDir / "player1.hki", tempFolder / "player1.hki", fs::copy_options::update_existing);
   } catch (std::exception const& e) {
     listener->error(e);
     listener->log(e.what());


### PR DESCRIPTION
These are the changes I used with the queueable tech exe update.

- Scenario editor crash is avoided by giving the queueable tech dummy units a name, this also helps with debugging when inspecting the dat file with AGE.
  - [x] <strike>This still requires an exe update so that the game does not attempt to show these units in the Buildings section in the first place.</strike>
- Assigns the queueable tech flag to the HideInEditor value